### PR TITLE
added revalidate key

### DIFF
--- a/starters/basic-starter/pages/[[...slug]].tsx
+++ b/starters/basic-starter/pages/[[...slug]].tsx
@@ -131,6 +131,6 @@ export async function getStaticProps(
       node,
       menus: await getMenus(),
     },
-    revalidate: 900,
+    revalidate: 60,
   };
 }

--- a/starters/basic-starter/pages/articles.tsx
+++ b/starters/basic-starter/pages/articles.tsx
@@ -59,5 +59,6 @@ export async function getStaticProps(
       articles,
       menus: await getMenus(),
     },
+    revalidate: 60,
   };
 }

--- a/starters/basic-starter/pages/events.tsx
+++ b/starters/basic-starter/pages/events.tsx
@@ -62,5 +62,6 @@ export async function getStaticProps(
       events,
       menus: await getMenus(),
     },
+    revalidate: 60,
   };
 }

--- a/starters/basic-starter/pages/people.tsx
+++ b/starters/basic-starter/pages/people.tsx
@@ -57,5 +57,6 @@ export async function getStaticProps(
       people,
       menus: await getMenus(),
     },
+    revalidate: 60,
   };
 }

--- a/starters/basic-starter/pages/places.tsx
+++ b/starters/basic-starter/pages/places.tsx
@@ -58,5 +58,6 @@ export async function getStaticProps(
       places,
       menus: await getMenus(),
     },
+    revalidate: 60,
   };
 }


### PR DESCRIPTION
getStaticPaths() was only used in [[..slug]].tsx and already had `fallback: blocking`