### PR TITLE
Added empty paths to getStaticPaths

### DIFF
--- a/starters/basic-starter/pages/[...slug].tsx
+++ b/starters/basic-starter/pages/[...slug].tsx
@@ -44,7 +44,7 @@ export default function NodePage({ node, menus }: NodePageProps) {
   );
 }
 
-// This fetches paths from Drupal and builds static pages.
+// Use the 'paths' key to specify wanted paths to be pre-rendered at build time.
 // See https://nextjs.org/docs/basic-features/data-fetching/get-static-paths.
 export async function getStaticPaths(context): Promise<GetStaticPathsResult> {
   return {

--- a/starters/basic-starter/pages/[...slug].tsx
+++ b/starters/basic-starter/pages/[...slug].tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { GetStaticPathsResult, GetStaticPropsResult } from 'next';
 import {
   DrupalNode,
-  getPathsFromContext,
   getResourceFromContext,
   translatePathFromContext,
 } from 'next-drupal';
@@ -49,7 +48,9 @@ export default function NodePage({ node, menus }: NodePageProps) {
 // See https://nextjs.org/docs/basic-features/data-fetching/get-static-paths.
 export async function getStaticPaths(context): Promise<GetStaticPathsResult> {
   return {
-    paths: await getPathsFromContext(CONTENT_TYPES, context),
+    // Don't pre-render all pages at build time and instead dynamically
+    // render the page on request.
+    paths: [],
     fallback: 'blocking',
   };
 }

--- a/starters/basic-starter/pages/[...slug].tsx
+++ b/starters/basic-starter/pages/[...slug].tsx
@@ -48,8 +48,8 @@ export default function NodePage({ node, menus }: NodePageProps) {
 // See https://nextjs.org/docs/basic-features/data-fetching/get-static-paths.
 export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   return {
-    // Don't pre-render all pages at build time and instead dynamically
-    // render the page on request.
+    // By default, individual entity pages are not pre-rendered at build time to
+    // optimize for faster build time.
     paths: [],
     fallback: 'blocking',
   };

--- a/starters/basic-starter/pages/[...slug].tsx
+++ b/starters/basic-starter/pages/[...slug].tsx
@@ -46,7 +46,7 @@ export default function NodePage({ node, menus }: NodePageProps) {
 
 // Use the 'paths' key to specify wanted paths to be pre-rendered at build time.
 // See https://nextjs.org/docs/basic-features/data-fetching/get-static-paths.
-export async function getStaticPaths(context): Promise<GetStaticPathsResult> {
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   return {
     // Don't pre-render all pages at build time and instead dynamically
     // render the page on request.


### PR DESCRIPTION
This PR is to stop the pre-rendering of all pages at build time and instead dynamically render on request.