### PR TITLE
Create ACMS project in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,9 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn prettier --check .
       - run: yarn run lint
+      - name: Create Acquia CMS project
+        uses: php-actions/composer@v6
+        with:
+          command: create-project
+          args: acquia/drupal-recommend-project acms
+          php_version: 7.4


### PR DESCRIPTION
To run end-to-end tests (and even to build the starter kit project in the first place) we'll need to create an Acquia CMS backend in CI. This is the first step; it executes an action to create an ACMS project.