### PR TITLE
Handle errors when there is no existing content

### DIFF
--- a/starters/basic-starter/pages/articles.tsx
+++ b/starters/basic-starter/pages/articles.tsx
@@ -34,26 +34,35 @@ export default function ArticlePage({ menus, articles }: ArticlesPageProps) {
 export async function getStaticProps(
   context,
 ): Promise<GetStaticPropsResult<ArticlesPageProps>> {
-  const articles = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
-    'node--article',
-    context,
-    {
-      params: new DrupalJsonApiParams()
-        .addFilter('status', '1')
-        .addSort('created', 'DESC')
-        .addInclude(['field_article_image.image', 'field_display_author'])
-        .addFields('node--article', [
-          'id',
-          'title',
-          'body',
-          'path',
-          'created',
-          'field_display_author',
-          'field_article_image',
-        ])
-        .getQueryObject(),
-    },
-  );
+  let articles;
+  try {
+    articles = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
+      'node--article',
+      context,
+      {
+        params: new DrupalJsonApiParams()
+          .addFilter('status', '1')
+          .addSort('created', 'DESC')
+          .addInclude(['field_article_image.image', 'field_display_author'])
+          .addFields('node--article', [
+            'id',
+            'title',
+            'body',
+            'path',
+            'created',
+            'field_display_author',
+            'field_article_image',
+          ])
+          .getQueryObject(),
+      },
+    );
+  } catch (e) {
+    console.log(
+      'There is likely no existing content of this type in Drupal.\n',
+      e,
+    );
+    articles = [];
+  }
 
   return {
     props: {

--- a/starters/basic-starter/pages/events.tsx
+++ b/starters/basic-starter/pages/events.tsx
@@ -34,29 +34,38 @@ export default function EventPage({ menus, events }: EventsPageProps) {
 export async function getStaticProps(
   context,
 ): Promise<GetStaticPropsResult<EventsPageProps>> {
-  const events = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
-    'node--event',
-    context,
-    {
-      params: new DrupalJsonApiParams()
-        .addFilter('status', '1')
-        .addSort('field_event_start', 'ASC')
-        .addFilter('field_event_start', new Date().toISOString(), '>=')
-        .addInclude(['field_event_image.image', 'field_event_place'])
-        .addFields('node--event', [
-          'id',
-          'title',
-          'body',
-          'path',
-          'field_event_start',
-          'field_event_image',
-          'field_event_duration',
-          'field_event_place',
-        ])
-        .addFields('node--place', ['title', 'path'])
-        .getQueryObject(),
-    },
-  );
+  let events;
+  try {
+    events = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
+      'node--event',
+      context,
+      {
+        params: new DrupalJsonApiParams()
+          .addFilter('status', '1')
+          .addSort('field_event_start', 'ASC')
+          .addFilter('field_event_start', new Date().toISOString(), '>=')
+          .addInclude(['field_event_image.image', 'field_event_place'])
+          .addFields('node--event', [
+            'id',
+            'title',
+            'body',
+            'path',
+            'field_event_start',
+            'field_event_image',
+            'field_event_duration',
+            'field_event_place',
+          ])
+          .addFields('node--place', ['title', 'path'])
+          .getQueryObject(),
+      },
+    );
+  } catch (e) {
+    console.log(
+      'There is likely no existing content of this type in Drupal.\n',
+      e,
+    );
+    events = [];
+  }
 
   return {
     props: {

--- a/starters/basic-starter/pages/index.tsx
+++ b/starters/basic-starter/pages/index.tsx
@@ -7,6 +7,7 @@ import { DrupalJsonApiParams } from 'drupal-jsonapi-params';
 import Image from 'next/image';
 import Link from 'next/link';
 import { drupal } from '../lib/drupal';
+import {InvalidEvent} from "react";
 
 interface IndexPageProps extends LayoutProps {
   events: DrupalNode[];
@@ -88,44 +89,62 @@ export default function IndexPage({ menus, events, places }: IndexPageProps) {
 export async function getStaticProps(
   context,
 ): Promise<GetStaticPropsResult<IndexPageProps>> {
-  const events = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
-    'node--event',
-    context,
-    {
-      params: new DrupalJsonApiParams()
-        .addFilter('status', '1')
-        .addSort('field_event_start', 'ASC')
-        .addFilter('field_event_start', new Date().toISOString(), '>=')
-        .addInclude(['field_event_image.image', 'field_event_place'])
-        .addFields('node--event', [
-          'id',
-          'title',
-          'path',
-          'field_event_start',
-          'field_event_image',
-          'field_event_place',
-        ])
-        .addFields('node--place', ['title', 'path'])
-        .getQueryObject(),
-    },
-  );
-  const places = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
-    'node--place',
-    context,
-    {
-      params: new DrupalJsonApiParams()
-        .addFilter('status', '1')
-        .addSort('title', 'ASC')
-        .addFields('node--place', [
-          'id',
-          'title',
-          'path',
-          'field_place_address',
-          'field_place_telephone',
-        ])
-        .getQueryObject(),
-    },
-  );
+  let events;
+  let places;
+  try {
+    events = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
+      'node--event',
+      context,
+      {
+        params: new DrupalJsonApiParams()
+          .addFilter('status', '1')
+          .addSort('field_event_start', 'ASC')
+          .addFilter('field_event_start', new Date().toISOString(), '>=')
+          .addInclude(['field_event_image.image', 'field_event_place'])
+          .addFields('node--event', [
+            'id',
+            'title',
+            'path',
+            'field_event_start',
+            'field_event_image',
+            'field_event_place',
+          ])
+          .addFields('node--place', ['title', 'path'])
+          .getQueryObject(),
+      },
+    );
+  } catch (e) {
+    console.log(
+      'There is likely no existing content of this type in Drupal.\n',
+      e,
+    );
+    events = [];
+  }
+  try {
+    places = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
+      'node--place',
+      context,
+      {
+        params: new DrupalJsonApiParams()
+          .addFilter('status', '1')
+          .addSort('title', 'ASC')
+          .addFields('node--place', [
+            'id',
+            'title',
+            'path',
+            'field_place_address',
+            'field_place_telephone',
+          ])
+          .getQueryObject(),
+      },
+    );
+  } catch (e) {
+    console.log(
+      'There is likely no existing content of this type in Drupal.\n',
+      e,
+    );
+    places = [];
+  }
   return {
     props: {
       menus: await getMenus(),

--- a/starters/basic-starter/pages/index.tsx
+++ b/starters/basic-starter/pages/index.tsx
@@ -7,7 +7,6 @@ import { DrupalJsonApiParams } from 'drupal-jsonapi-params';
 import Image from 'next/image';
 import Link from 'next/link';
 import { drupal } from '../lib/drupal';
-import {InvalidEvent} from "react";
 
 interface IndexPageProps extends LayoutProps {
   events: DrupalNode[];

--- a/starters/basic-starter/pages/people.tsx
+++ b/starters/basic-starter/pages/people.tsx
@@ -34,24 +34,33 @@ export default function PeoplePage({ menus, people }: PeoplePageProps) {
 export async function getStaticProps(
   context,
 ): Promise<GetStaticPropsResult<PeoplePageProps>> {
-  const people = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
-    'node--person',
-    context,
-    {
-      params: new DrupalJsonApiParams()
-        .addFilter('status', '1')
-        .addSort('title', 'ASC')
-        .addInclude(['field_person_image.image'])
-        .addFields('node--person', [
-          'id',
-          'title',
-          'path',
-          'field_job_title',
-          'field_person_image',
-        ])
-        .getQueryObject(),
-    },
-  );
+  let people;
+  try {
+    people = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
+      'node--person',
+      context,
+      {
+        params: new DrupalJsonApiParams()
+          .addFilter('status', '1')
+          .addSort('title', 'ASC')
+          .addInclude(['field_person_image.image'])
+          .addFields('node--person', [
+            'id',
+            'title',
+            'path',
+            'field_job_title',
+            'field_person_image',
+          ])
+          .getQueryObject(),
+      },
+    );
+  } catch (e) {
+    console.log(
+      'There is likely no existing content of this type in Drupal.\n',
+      e,
+    );
+    people = [];
+  }
 
   return {
     props: {

--- a/starters/basic-starter/pages/places.tsx
+++ b/starters/basic-starter/pages/places.tsx
@@ -34,25 +34,34 @@ export default function PlacesPage({ menus, places }: PlacesPageProps) {
 export async function getStaticProps(
   context,
 ): Promise<GetStaticPropsResult<PlacesPageProps>> {
-  const places = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
-    'node--place',
-    context,
-    {
-      params: new DrupalJsonApiParams()
-        .addFilter('status', '1')
-        .addSort('title', 'ASC')
-        .addInclude(['field_place_image.image'])
-        .addFields('node--place', [
-          'id',
-          'title',
-          'path',
-          'field_place_image',
-          'field_place_address',
-          'field_place_telephone',
-        ])
-        .getQueryObject(),
-    },
-  );
+  let places;
+  try {
+    places = await drupal.getResourceCollectionFromContext<DrupalNode[]>(
+      'node--place',
+      context,
+      {
+        params: new DrupalJsonApiParams()
+          .addFilter('status', '1')
+          .addSort('title', 'ASC')
+          .addInclude(['field_place_image.image'])
+          .addFields('node--place', [
+            'id',
+            'title',
+            'path',
+            'field_place_image',
+            'field_place_address',
+            'field_place_telephone',
+          ])
+          .getQueryObject(),
+      },
+    );
+  } catch (e) {
+    console.log(
+      'There is likely no existing content of this type in Drupal.\n',
+      e,
+    );
+    places = [];
+  }
 
   return {
     props: {


### PR DESCRIPTION
This PR adds a try/catch when there is resource fetching. If there is an error with the fetching (no existing content), the catch returns an empty array and will still display the page without crashing.