### PR TITLE
Run end-to-end tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
           yarn dev &
           sleep 8
       - name: Run end-to-end tests
-        run: docker run --volume $PWD:/e2e --workdir /e2e --publish 3000:3000 cypress/included:10.3.1
+        run: docker run --volume $PWD:/e2e --workdir /e2e --publish 3001:3000 cypress/included:10.3.1 --config baseUrl=http://localhost:3001

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,6 @@ jobs:
           yarn dev &
           sleep 8
           curl --fail http://localhost:3000
+
 #      - name: Run end-to-end tests
 #        run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1 --config baseUrl=http://host.docker.internal:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,6 @@ jobs:
       - name: Run application
         run: |
           yarn dev &
-          sleep 5
+          sleep 8
+      - name: Run end-to-end tests
+        run: docker run --interactive --tty --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,7 @@ jobs:
         run: |
           cp ./drupal/.env ./starters/basic-starter/.env.local
           yarn build
+      - name: Run application
+        run: |
+          yarn dev &
+          sleep 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,4 @@ jobs:
           yarn dev &
           sleep 8
       - name: Run end-to-end tests
-        uses: docker://cypress/included:10.3.1
-        with:
-          args: '--volume $PWD:/e2e --workdir /e2e --publish 3001:3000'
+        run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1 --config baseUrl=http://host.docker.internal:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,4 @@ jobs:
           yarn dev &
           sleep 8
       - name: Run end-to-end tests
-        run: docker run --interactive --tty --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1
+        run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,6 @@ jobs:
           yarn build
           yarn dev &
           sleep 8
-      - name: Run end-to-end tests
-        run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1 --config baseUrl=http://host.docker.internal:3000
+          curl --fail http://localhost:3000
+#      - name: Run end-to-end tests
+#        run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1 --config baseUrl=http://host.docker.internal:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,4 @@ jobs:
           yarn dev &
           sleep 8
       - name: Run end-to-end tests
-        uses: docker://cypress/included:10.3.1
-        with:
-          options: '--volume $PWD:/e2e --workdir /e2e'
-        # run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1
+        run: docker run --volume $PWD:/e2e --workdir /e2e --publish 3000:3000 cypress/included:10.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,14 @@ jobs:
       - name: Run jest unit tests
         run: yarn run test:jest
 
-      - name: Build application
+      - name: Build and start application
         run: |
           cp ./drupal/.env ./starters/basic-starter/.env.local
           yarn build
-      - name: Run application
-        run: |
           yarn dev &
           sleep 8
       - name: Run end-to-end tests
-        run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1
+        uses: docker://cypress/included:10.3.1
+        with:
+          options: '--volume $PWD:/e2e --workdir /e2e'
+        # run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,5 @@ jobs:
           sleep 8
           curl --fail http://localhost:3000
 
-#      - name: Run end-to-end tests
-#        run: docker run --volume $PWD:/e2e --workdir /e2e cypress/included:10.3.1 --config baseUrl=http://host.docker.internal:3000
+      - name: Run end-to-end tests
+        run: docker run --volume $PWD:/e2e --workdir /e2e --add-host host.docker.internal:host-gateway cypress/included:10.3.1 --config baseUrl=http://host.docker.internal:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,6 @@ jobs:
           yarn dev &
           sleep 8
       - name: Run end-to-end tests
-        run: docker run --volume $PWD:/e2e --workdir /e2e --publish 3001:3000 cypress/included:10.3.1 --config baseUrl=http://127.0.0.1:3001
+        uses: docker://cypress/included:10.3.1
+        with:
+          args: '--volume $PWD:/e2e --workdir /e2e --publish 3001:3000'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
           yarn dev &
           sleep 8
       - name: Run end-to-end tests
-        run: docker run --volume $PWD:/e2e --workdir /e2e --publish 3001:3000 cypress/included:10.3.1 --config baseUrl=http://localhost:3001
+        run: docker run --volume $PWD:/e2e --workdir /e2e --publish 3001:3000 cypress/included:10.3.1 --config baseUrl=http://127.0.0.1:3001

--- a/cypress/e2e/basic-starter.cy.ts
+++ b/cypress/e2e/basic-starter.cy.ts
@@ -132,6 +132,7 @@ describe('Taxonomy term page', () => {
   it('should render places for Office (place type)', () => {
     cy.visit('/taxonomy/term/13');
     cy.get('h1').should('contain.text', 'Office');
+    cy.get('h2', { timeout: 5000 }).should('be.visible');
     cy.get('article')
       .should('have.length.greaterThan', 1)
       .find('h2')


### PR DESCRIPTION
Does what it says on the tin: it runs the end-to-end tests with Cypress. Finally.

In subsequent PRs I'd like to add some caching to speed up the builds (in particular, we could speed up the installation of JavaScript dependencies and, hopefully, the Cypress container images). But that doesn't need to happen here.