### PR TITLE
Disable Cypress videos on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,4 @@ jobs:
           curl --fail http://localhost:3000
 
       - name: Run end-to-end tests
-        run: docker run --volume $PWD:/e2e --workdir /e2e --add-host host.docker.internal:host-gateway cypress/included:10.3.1 --config baseUrl=http://host.docker.internal:3000
+        run: docker run --volume $PWD:/e2e --workdir /e2e --add-host host.docker.internal:host-gateway cypress/included:10.3.1 --config baseUrl=http://host.docker.internal:3000,video=false


### PR DESCRIPTION
Cypress takes videos of the test runs by default. This is useful for local development but not so much for CI. So let's disable it, and shave a little time off the whole job.