### PR TITLE
Fix broken Yarn caching on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+        # See https://stackoverflow.com/questions/61010294/how-to-cache-yarn-packages-in-github-actions
       - name: Install Yarn dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --prefer-offline
 
       - run: yarn prettier --check .
       - run: yarn run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,22 @@ jobs:
         run: |
           npm --version
           npm -g install yarn
-      - run: yarn install --frozen-lockfile
+
+      # Copied from https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - name: Get Yarn cache path
+        id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install Yarn dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
       - run: yarn prettier --check .
       - run: yarn run lint
       - name: Run jest unit tests


### PR DESCRIPTION
Well, #96 didn't quite work, but I think (from researching https://stackoverflow.com/questions/61010294/how-to-cache-yarn-packages-in-github-actions), it's because even though we restore the cache directory, but don't actually create `node_modules`.