### PR TITLE
Fix preview mode on development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ $ git remote add upstream https://github.com/acquia/next-acms
 3. Create an `.env.local` file in the `/starters/basic-starter` directory in your forked repo and paste in your environment variables from step 1.
 4. From the root directory, run `yarn install` then `yarn dev` to start the development server on `http://localhost:3000`.
 
-   > **_NOTE:_** Next.js preview mode only works in production mode. To run in production mode, run `yarn build` then `yarn start` inside the `starters/basic-starter` directory.
+   > To run in production mode, run `yarn preview` inside the `starters/basic-starter` directory.
 
 5. Now you can make changes to your repo, commit them, push them up to your remote, then create a pull request for `acquia/next-acms` to contribute.
 

--- a/starters/basic-starter/lib/drupal.ts
+++ b/starters/basic-starter/lib/drupal.ts
@@ -9,5 +9,8 @@ export const drupal = new DrupalClient(
       clientSecret: process.env.DRUPAL_CLIENT_SECRET,
     },
     withAuth: true,
+    // @see https://github.com/vercel/next.js/discussions/32238
+    // @see https://github.com/vercel/next.js/blob/d895a50abbc8f91726daa2d7ebc22c58f58aabbb/packages/next/server/api-utils/node.ts#L504
+    forceIframeSameSiteCookie: process.env.NODE_ENV === 'development',
   },
 );


### PR DESCRIPTION
Related to #11.

Before this, preview on development mode would not try to fetch the latest revision which leads into confusing behavior. We had previously documented that the preview mode doesn't work on development mode, so we should update that.