### PR TITLE
Fix init-env.php to account for upstream changes

### DIFF
--- a/drupal/init-env.php
+++ b/drupal/init-env.php
@@ -77,7 +77,10 @@ $consumer->set('roles', 'headless');
 $consumer->set('user_id', $account->id());
 $consumer->save();
 
-$site = $starter_kit->createHeadlessSite();
+$site = $starter_kit->createHeadlessSite('headless', [
+  'site-name' => 'Headless Site 1',
+  'site-url' => 'http://localhost:3000/',
+]);
 $starter_kit->createHeadlessSiteEntities();
 
 // The starter kit service sets these values, but doesn't save them. SMH.


### PR DESCRIPTION
Right now the container image cannot be rebuilt because a function signature changed upstream, and `init-env.php` is not calling it correctly. Let's fix that so I can rebuild the container...