### PR TITLE
Enable coh_medium image style for the headless consumer

### DIFF
--- a/drupal/init-env.php
+++ b/drupal/init-env.php
@@ -75,6 +75,7 @@ $consumer->set('is_default', TRUE);
 $consumer->set('redirect', 'http://localhost:3000');
 $consumer->set('roles', 'headless');
 $consumer->set('user_id', $account->id());
+$consumer->image_styles->target_id = 'coh_medium';
 $consumer->save();
 
 $site = $starter_kit->createHeadlessSite('headless', [


### PR DESCRIPTION
This brings the container build script in line with the needs of #102 (the image was already rebuilt locally by me, manually checked, and pushed to Docker Hub).