### PR TITLE
Add a new workflow to rebuild the container image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,12 @@
+name: Container Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build container image and push it to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Say hello
+        run: echo "Hello!"


### PR DESCRIPTION
The documentation is unclear, but I suspect that, to iteratively work on this workflow and run it on demand, we will first need to add it to the main branch of this repo. So, here's a stub workflow that just says hi. If we can run it on demand after commit, I can continue adding stuff to it and actually getting the image rebuilt.