### PR TITLE
Update basic-starter to Next.js 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@next/eslint-plugin-next": "12.3.2",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^12.1.5",
+    "@testing-library/react": "^13.4.0",
     "@types/jest": "^28.1.6",
     "@types/node": "^18.11.9",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
@@ -37,10 +37,10 @@
     "turbo": "^1.6.3"
   },
   "dependencies": {
-    "next": "^12.3.2",
+    "next": "^13.0.0",
     "next-drupal": "^1.5.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "typescript": "^4.8.4"
   }
 }

--- a/packages/next-acms/package.json
+++ b/packages/next-acms/package.json
@@ -22,7 +22,7 @@
     "dev": "microbundle watch --no-compress --jsx React.createElement"
   },
   "peerDependencies": {
-    "next": "^12.2.0",
+    "next": "^12.2.0 || ^13.0.0",
     "next-drupal": "^1.4.0"
   },
   "devDependencies": {

--- a/starters/basic-starter/components/formatted-text.tsx
+++ b/starters/basic-starter/components/formatted-text.tsx
@@ -44,8 +44,8 @@ const options: HTMLReactParserOptions = {
 
         if (href && isRelative(href)) {
           return (
-            <Link href={href} passHref>
-              <a className={className}>{domToReact(domNode.children)}</a>
+            <Link href={href} className={className}>
+              {domToReact(domNode.children)}
             </Link>
           );
         }

--- a/starters/basic-starter/components/formatted-text.tsx
+++ b/starters/basic-starter/components/formatted-text.tsx
@@ -18,8 +18,8 @@ const options: HTMLReactParserOptions = {
           src,
           alt,
           class: className,
-          width = '100px',
-          height = '100px',
+          width = '100',
+          height = '100',
         } = domNode.attribs;
 
         if (isRelative(src)) {
@@ -27,11 +27,10 @@ const options: HTMLReactParserOptions = {
             <div className={className}>
               <Image
                 src={absoluteURL(`/${src}`)}
-                width={`${width}px`}
-                height={`${height}px`}
+                width={Number(width)}
+                height={Number(height)}
                 alt={alt}
-                layout="intrinsic"
-                objectFit="cover"
+                sizes="(min-width: 768px) 625px, 100vw"
               />
             </div>
           );

--- a/starters/basic-starter/components/layout.tsx
+++ b/starters/basic-starter/components/layout.tsx
@@ -20,7 +20,7 @@ export function Layout({ title, menus, children }: LayoutProps) {
   return (
     <>
       <Head>
-        <title>{title} - Acquia CMS</title>
+        <title>{`${title} - Acquia CMS`}</title>
       </Head>
       <PreviewAlert />
       <div className="flex flex-col min-h-screen">

--- a/starters/basic-starter/components/layout.tsx
+++ b/starters/basic-starter/components/layout.tsx
@@ -26,7 +26,10 @@ export function Layout({ title, menus, children }: LayoutProps) {
       <div className="flex flex-col min-h-screen">
         <header className="border-b">
           <div className="container flex flex-col items-center justify-between px-6 py-4 mx-auto md:flex-row">
-            <Link href="/" className="flex items-center mb-4 space-x-2 no-underline md:mb-0">
+            <Link
+              href="/"
+              className="flex items-center mb-4 space-x-2 no-underline md:mb-0"
+            >
               <div className="w-8 h-10">
                 <Image src="/logo.png" alt="Logo" width={76} height={90} />
               </div>

--- a/starters/basic-starter/components/layout.tsx
+++ b/starters/basic-starter/components/layout.tsx
@@ -26,13 +26,11 @@ export function Layout({ title, menus, children }: LayoutProps) {
       <div className="flex flex-col min-h-screen">
         <header className="border-b">
           <div className="container flex flex-col items-center justify-between px-6 py-4 mx-auto md:flex-row">
-            <Link href="/" passHref>
-              <a className="flex items-center mb-4 space-x-2 no-underline md:mb-0">
-                <div className="w-8 h-10">
-                  <Image src="/logo.png" alt="Logo" width={76} height={90} />
-                </div>
-                <span className="text-lg font-semibold">Acquia CMS</span>
-              </a>
+            <Link href="/" className="flex items-center mb-4 space-x-2 no-underline md:mb-0">
+              <div className="w-8 h-10">
+                <Image src="/logo.png" alt="Logo" width={76} height={90} />
+              </div>
+              <span className="text-lg font-semibold">Acquia CMS</span>
             </Link>
             {menus?.main && <MenuMain menu={menus.main} />}
           </div>

--- a/starters/basic-starter/components/media--image.tsx
+++ b/starters/basic-starter/components/media--image.tsx
@@ -12,13 +12,16 @@ MediaImage.type = 'media--image';
 
 export function MediaImage({
   media,
-  layout = 'responsive',
-  objectFit,
+  imageStyle,
+  fill = false,
   width,
   height,
   priority,
+  quality,
   sizes,
-  imageStyle,
+  placeholder,
+  blurDataURL,
+  loading,
   ...props
 }: MediaImageProps) {
   const image = media?.image;
@@ -29,13 +32,12 @@ export function MediaImage({
   let sizeProps;
   let srcURL;
 
-  sizeProps =
-    layout === 'fill'
-      ? null
-      : {
-          width: width || image.resourceIdObjMeta.width,
-          height: height || image.resourceIdObjMeta.height,
-        };
+  sizeProps = fill
+    ? null
+    : {
+        width: width || image.resourceIdObjMeta.width,
+        height: height || image.resourceIdObjMeta.height,
+      };
   srcURL = absoluteURL(image.uri.url);
 
   // Use the image style to render an image if specified.
@@ -64,13 +66,16 @@ export function MediaImage({
     <div className="media__content image__wrapper" {...props}>
       <Image
         src={srcURL}
-        layout={layout}
-        objectFit={objectFit}
         alt={image.resourceIdObjMeta.alt || 'Image'}
         title={image.resourceIdObjMeta.title}
         priority={priority}
         sizes={sizes}
-        {...sizeProps}
+        fill={fill}
+        quality={quality}
+        blurDataURL={blurDataURL}
+        loading={loading}
+        placeholder={placeholder}
+        {...(!fill ? sizeProps : {})}
       />
     </div>
   );

--- a/starters/basic-starter/components/menu--footer.tsx
+++ b/starters/basic-starter/components/menu--footer.tsx
@@ -29,14 +29,10 @@ export function MenuFooter({ menu, ...props }: MenuFooterProps) {
                 'menu-item--active-trail': isActive,
               })}
             >
-              <Link href={item.url} passHref>
-                <a
-                  className={classNames(
-                    isActive ? 'text-black' : 'text-gray-600',
-                  )}
-                >
-                  {item.title}
-                </a>
+              <Link href={item.url} className={classNames(
+                isActive ? 'text-black' : 'text-gray-600',
+              )}>
+                {item.title}
               </Link>
             </li>
           );

--- a/starters/basic-starter/components/menu--footer.tsx
+++ b/starters/basic-starter/components/menu--footer.tsx
@@ -29,9 +29,12 @@ export function MenuFooter({ menu, ...props }: MenuFooterProps) {
                 'menu-item--active-trail': isActive,
               })}
             >
-              <Link href={item.url} className={classNames(
-                isActive ? 'text-black' : 'text-gray-600',
-              )}>
+              <Link
+                href={item.url}
+                className={classNames(
+                  isActive ? 'text-black' : 'text-gray-600',
+                )}
+              >
                 {item.title}
               </Link>
             </li>

--- a/starters/basic-starter/components/menu--main.tsx
+++ b/starters/basic-starter/components/menu--main.tsx
@@ -29,14 +29,10 @@ export function MenuMain({ menu, ...props }: MenuMainProps) {
                 'menu-item--active-trail': isActive,
               })}
             >
-              <Link href={item.url} passHref>
-                <a
-                  className={classNames('hover:text-blue-600', {
-                    'text-blue-600': isActive,
-                  })}
-                >
+              <Link href={item.url}               className={classNames('hover:text-blue-600', {
+                'text-blue-600': isActive,
+              })}>
                   {item.title}
-                </a>
               </Link>
             </li>
           );

--- a/starters/basic-starter/components/menu--main.tsx
+++ b/starters/basic-starter/components/menu--main.tsx
@@ -29,10 +29,13 @@ export function MenuMain({ menu, ...props }: MenuMainProps) {
                 'menu-item--active-trail': isActive,
               })}
             >
-              <Link href={item.url}               className={classNames('hover:text-blue-600', {
-                'text-blue-600': isActive,
-              })}>
-                  {item.title}
+              <Link
+                href={item.url}
+                className={classNames('hover:text-blue-600', {
+                  'text-blue-600': isActive,
+                })}
+              >
+                {item.title}
               </Link>
             </li>
           );

--- a/starters/basic-starter/components/node--article.tsx
+++ b/starters/basic-starter/components/node--article.tsx
@@ -56,14 +56,12 @@ export function NodeArticleTeaser({ node, ...props }) {
   return (
     <article className="flex flex-col space-y-4" {...props}>
       {node.field_article_image && (
-        <Link href={node.path.alias} passHref>
-          <a className="block overflow-hidden no-underline rounded-md">
-            <MediaImage
-              media={node.field_article_image}
-              priority
-              sizes="(min-width: 968px) 420px, (min-width: 768px) 50vw, 100vw"
-            />
-          </a>
+        <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+          <MediaImage
+            media={node.field_article_image}
+            priority
+            sizes="(min-width: 968px) 420px, (min-width: 768px) 50vw, 100vw"
+          />
         </Link>
       )}
       <div>
@@ -78,10 +76,8 @@ export function NodeArticleTeaser({ node, ...props }) {
           ) : null}
           {node.created && <span> on {formatDate(node.created)}</span>}
         </p>
-        <Link href={node.path.alias} passHref>
-          <a className="no-underline hover:text-blue-600">
-            <h2 className="mb-4 text-xl font-bold">{node.title}</h2>
-          </a>
+        <Link href={node.path.alias} className="no-underline hover:text-blue-600">
+          <h2 className="mb-4 text-xl font-bold">{node.title}</h2>
         </Link>
         {node.body?.summary && (
           <p className="text-gray-500" data-cy="summary">

--- a/starters/basic-starter/components/node--article.tsx
+++ b/starters/basic-starter/components/node--article.tsx
@@ -56,7 +56,10 @@ export function NodeArticleTeaser({ node, ...props }) {
   return (
     <article className="flex flex-col space-y-4" {...props}>
       {node.field_article_image && (
-        <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+        <Link
+          href={node.path.alias}
+          className="block overflow-hidden no-underline rounded-md"
+        >
           <MediaImage
             media={node.field_article_image}
             priority
@@ -76,7 +79,10 @@ export function NodeArticleTeaser({ node, ...props }) {
           ) : null}
           {node.created && <span> on {formatDate(node.created)}</span>}
         </p>
-        <Link href={node.path.alias} className="no-underline hover:text-blue-600">
+        <Link
+          href={node.path.alias}
+          className="no-underline hover:text-blue-600"
+        >
           <h2 className="mb-4 text-xl font-bold">{node.title}</h2>
         </Link>
         {node.body?.summary && (

--- a/starters/basic-starter/components/node--event.tsx
+++ b/starters/basic-starter/components/node--event.tsx
@@ -9,15 +9,13 @@ export function NodeEvent({ node, ...props }) {
     <article className="container px-6 py-10 mx-auto" {...props}>
       <div className="grid-cols-2 gap-10 p-4 mx-auto border rounded-md md:grid">
         {node.field_event_image && (
-          <Link href={node.path.alias} passHref>
-            <a className="block overflow-hidden no-underline rounded-md">
-              <MediaImage
-                media={node.field_event_image}
-                priority
-                sizes="(min-width: 968px) 410px, (min-width: 768px) 50vw, 100vw"
-                imageStyle="coh_medium"
-              />
-            </a>
+          <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+            <MediaImage
+              media={node.field_event_image}
+              priority
+              sizes="(min-width: 968px) 410px, (min-width: 768px) 50vw, 100vw"
+              imageStyle="coh_medium"
+            />
           </Link>
         )}
         <div className="mt-8">
@@ -62,14 +60,12 @@ export function NodeEventTeaser({ node, ...props }) {
       {...props}
     >
       {node.field_event_image && (
-        <Link href={node.path.alias} passHref>
-          <a className="block overflow-hidden no-underline rounded-md">
-            <MediaImage
-              media={node.field_event_image}
-              priority
-              sizes="(min-width: 768px) 140px, 100wh"
-            />
-          </a>
+        <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+          <MediaImage
+            media={node.field_event_image}
+            priority
+            sizes="(min-width: 768px) 140px, 100wh"
+          />
         </Link>
       )}
       <div className="col-span-2">
@@ -90,10 +86,8 @@ export function NodeEventTeaser({ node, ...props }) {
             </span>
           )}
         </div>
-        <Link href={node.path.alias} passHref>
-          <a className="no-underline hover:text-blue-600">
-            <h2 className="mb-4 text-3xl font-bold">{node.title}</h2>
-          </a>
+        <Link href={node.path.alias} className="no-underline hover:text-blue-600">
+          <h2 className="mb-4 text-3xl font-bold">{node.title}</h2>
         </Link>
         {node.body?.summary && (
           <p className="text-sm text-gray-500">{node.body.summary}</p>

--- a/starters/basic-starter/components/node--event.tsx
+++ b/starters/basic-starter/components/node--event.tsx
@@ -9,7 +9,10 @@ export function NodeEvent({ node, ...props }) {
     <article className="container px-6 py-10 mx-auto" {...props}>
       <div className="grid-cols-2 gap-10 p-4 mx-auto border rounded-md md:grid">
         {node.field_event_image && (
-          <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+          <Link
+            href={node.path.alias}
+            className="block overflow-hidden no-underline rounded-md"
+          >
             <MediaImage
               media={node.field_event_image}
               priority
@@ -60,7 +63,10 @@ export function NodeEventTeaser({ node, ...props }) {
       {...props}
     >
       {node.field_event_image && (
-        <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+        <Link
+          href={node.path.alias}
+          className="block overflow-hidden no-underline rounded-md"
+        >
           <MediaImage
             media={node.field_event_image}
             priority
@@ -86,7 +92,10 @@ export function NodeEventTeaser({ node, ...props }) {
             </span>
           )}
         </div>
-        <Link href={node.path.alias} className="no-underline hover:text-blue-600">
+        <Link
+          href={node.path.alias}
+          className="no-underline hover:text-blue-600"
+        >
           <h2 className="mb-4 text-3xl font-bold">{node.title}</h2>
         </Link>
         {node.body?.summary && (

--- a/starters/basic-starter/components/node--person.tsx
+++ b/starters/basic-starter/components/node--person.tsx
@@ -39,21 +39,17 @@ export function NodePersonTeaser({ node, ...props }) {
       {...props}
     >
       {node.field_person_image && (
-        <Link href={node.path.alias} passHref>
-          <a className="block w-32 h-32 overflow-hidden no-underline rounded-full">
-            <MediaImage
-              media={node.field_person_image}
-              priority
-              sizes="128px"
-            />
-          </a>
+        <Link href={node.path.alias} className="block w-32 h-32 overflow-hidden no-underline rounded-full">
+          <MediaImage
+            media={node.field_person_image}
+            priority
+            sizes="128px"
+          />
         </Link>
       )}
       <div className="space-y-2">
-        <Link href={node.path.alias} passHref>
-          <a className="no-underline hover:text-blue-600">
-            <h2 className="text-xl">{node.title}</h2>
-          </a>
+        <Link href={node.path.alias} className="no-underline hover:text-blue-600">
+          <h2 className="text-xl">{node.title}</h2>
         </Link>
         {node.field_job_title && (
           <p className="text-gray-600">{node.field_job_title}</p>

--- a/starters/basic-starter/components/node--person.tsx
+++ b/starters/basic-starter/components/node--person.tsx
@@ -39,16 +39,18 @@ export function NodePersonTeaser({ node, ...props }) {
       {...props}
     >
       {node.field_person_image && (
-        <Link href={node.path.alias} className="block w-32 h-32 overflow-hidden no-underline rounded-full">
-          <MediaImage
-            media={node.field_person_image}
-            priority
-            sizes="128px"
-          />
+        <Link
+          href={node.path.alias}
+          className="block w-32 h-32 overflow-hidden no-underline rounded-full"
+        >
+          <MediaImage media={node.field_person_image} priority sizes="128px" />
         </Link>
       )}
       <div className="space-y-2">
-        <Link href={node.path.alias} className="no-underline hover:text-blue-600">
+        <Link
+          href={node.path.alias}
+          className="no-underline hover:text-blue-600"
+        >
           <h2 className="text-xl">{node.title}</h2>
         </Link>
         {node.field_job_title && (

--- a/starters/basic-starter/components/node--place.tsx
+++ b/starters/basic-starter/components/node--place.tsx
@@ -8,7 +8,10 @@ export function NodePlace({ node, ...props }) {
     <article {...props}>
       <div className="grid items-start w-full max-w-4xl gap-10 px-6 pt-12 mx-auto md:grid-cols-2">
         {node.field_place_image && (
-          <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+          <Link
+            href={node.path.alias}
+            className="block overflow-hidden no-underline rounded-md"
+          >
             <MediaImage
               media={node.field_place_image}
               priority
@@ -49,7 +52,10 @@ export function NodePlaceTeaser({ node, ...props }) {
       {...props}
     >
       {node.field_place_image && (
-        <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+        <Link
+          href={node.path.alias}
+          className="block overflow-hidden no-underline rounded-md"
+        >
           <MediaImage
             media={node.field_place_image}
             priority
@@ -58,7 +64,10 @@ export function NodePlaceTeaser({ node, ...props }) {
         </Link>
       )}
       <div className="space-y-4">
-        <Link href={node.path.alias} className="no-underline hover:text-blue-600">
+        <Link
+          href={node.path.alias}
+          className="no-underline hover:text-blue-600"
+        >
           <h2 className="text-3xl font-bold">{node.title}</h2>
         </Link>
         {node.field_place_address && (

--- a/starters/basic-starter/components/node--place.tsx
+++ b/starters/basic-starter/components/node--place.tsx
@@ -8,14 +8,12 @@ export function NodePlace({ node, ...props }) {
     <article {...props}>
       <div className="grid items-start w-full max-w-4xl gap-10 px-6 pt-12 mx-auto md:grid-cols-2">
         {node.field_place_image && (
-          <Link href={node.path.alias} passHref>
-            <a className="block overflow-hidden no-underline rounded-md">
-              <MediaImage
-                media={node.field_place_image}
-                priority
-                sizes="(min-width: 968px) 405px, (min-width: 768px) 50vw, 100vw"
-              />
-            </a>
+          <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+            <MediaImage
+              media={node.field_place_image}
+              priority
+              sizes="(min-width: 968px) 405px, (min-width: 768px) 50vw, 100vw"
+            />
           </Link>
         )}
         <div className="space-y-4">
@@ -51,21 +49,17 @@ export function NodePlaceTeaser({ node, ...props }) {
       {...props}
     >
       {node.field_place_image && (
-        <Link href={node.path.alias} passHref>
-          <a className="block overflow-hidden no-underline rounded-md">
-            <MediaImage
-              media={node.field_place_image}
-              priority
-              sizes="(min-width: 968px) 425px, (min-width: 768px) 50vw, 100vw"
-            />
-          </a>
+        <Link href={node.path.alias} className="block overflow-hidden no-underline rounded-md">
+          <MediaImage
+            media={node.field_place_image}
+            priority
+            sizes="(min-width: 968px) 425px, (min-width: 768px) 50vw, 100vw"
+          />
         </Link>
       )}
       <div className="space-y-4">
-        <Link href={node.path.alias} passHref>
-          <a className="no-underline hover:text-blue-600">
-            <h2 className="text-3xl font-bold">{node.title}</h2>
-          </a>
+        <Link href={node.path.alias} className="no-underline hover:text-blue-600">
+          <h2 className="text-3xl font-bold">{node.title}</h2>
         </Link>
         {node.field_place_address && (
           <div>

--- a/starters/basic-starter/package.json
+++ b/starters/basic-starter/package.json
@@ -15,11 +15,11 @@
     "classnames": "^2.3.2",
     "drupal-jsonapi-params": "^2.1.0",
     "html-react-parser": "^3.0.4",
-    "next": "^12.3.2",
+    "next": "^13.0.0",
     "next-acms": "^1.0.0",
     "next-drupal": "^1.5.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "sharp": "^0.31.2"
   },
   "devDependencies": {

--- a/starters/basic-starter/package.json
+++ b/starters/basic-starter/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.2",
     "@types/node": "^18.11.9",
-    "@types/react": "^17.0.4",
+    "@types/react": "^18.0.25",
     "autoprefixer": "^10.4.13",
     "eslint": "^8.27.0",
     "eslint-config-next": "^12.3.2",

--- a/starters/basic-starter/pages/index.tsx
+++ b/starters/basic-starter/pages/index.tsx
@@ -65,10 +65,8 @@ export default function IndexPage({ menus, events, places }: IndexPageProps) {
           <div className="grid gap-14" data-cy="contact-us">
             {places.slice(0, 3).map((place) => (
               <article key={place.id}>
-                <Link href={place.path.alias} passHref>
-                  <a className="no-underline hover:text-blue-600">
-                    <h2 className="text-3xl font-bold">{place.title}</h2>
-                  </a>
+                <Link href={place.path.alias} className="no-underline hover:text-blue-600">
+                  <h2 className="text-3xl font-bold">{place.title}</h2>
                 </Link>
                 <p className="text-lg text-gray-600">
                   {place.field_place_telephone}

--- a/starters/basic-starter/pages/index.tsx
+++ b/starters/basic-starter/pages/index.tsx
@@ -38,8 +38,9 @@ export default function IndexPage({ menus, events, places }: IndexPageProps) {
               <Image
                 src="/CMS_icon_0.png"
                 alt="Logo"
-                width={200}
-                height={227}
+                priority
+                width={256}
+                height={301}
               />
             </div>
           </div>
@@ -65,7 +66,10 @@ export default function IndexPage({ menus, events, places }: IndexPageProps) {
           <div className="grid gap-14" data-cy="contact-us">
             {places.slice(0, 3).map((place) => (
               <article key={place.id}>
-                <Link href={place.path.alias} className="no-underline hover:text-blue-600">
+                <Link
+                  href={place.path.alias}
+                  className="no-underline hover:text-blue-600"
+                >
                   <h2 className="text-3xl font-bold">{place.title}</h2>
                 </Link>
                 <p className="text-lg text-gray-600">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,19 +1932,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@^18.0.25":
   version "18.0.25"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.25.tgz#8b1dcd7e56fe7315535a4af25435e0bb55c8ae44"
   integrity sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0.4":
-  version "17.0.48"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.48.tgz#a4532a8b91d7b27b8768b6fc0c3bccb760d15a6c"
-  integrity sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,10 +1446,10 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-12.2.0.tgz#17ce2d9f5532b677829840037e06f208b7eed66b"
   integrity sha512-/FCkDpL/8SodJEXvx/DYNlOD5ijTtkozf4PPulYPtkPOJaMPpBSOkzmsta4fnrnbdH6eZjbwbiXFdr6gSQCV4w==
 
-"@next/env@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.2.tgz#fb819366771f5721e9438ca3a42ad18684f0949b"
-  integrity sha512-upwtMaHxlv/udAWGq0kE+rg8huwmcxQPsKZFhS1R5iVO323mvxEBe1YrSXe1awLbg9sTIuEHbgxjLLt7JbeuAQ==
+"@next/env@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.0.2.tgz#5fbd7b4146175ae406edfb4a38b62de8c880c09d"
+  integrity sha512-Qb6WPuRriGIQ19qd6NBxpcrFOfj8ziN7l9eZUfwff5gl4zLXluqtuZPddYZM/oWjN53ZYcuRXzL+oowKyJeYtA==
 
 "@next/eslint-plugin-next@12.3.2":
   version "12.3.2"
@@ -1463,130 +1463,130 @@
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.0.tgz#f116756e668b267de84b76f068d267a12f18eb22"
   integrity sha512-hbneH8DNRB2x0Nf5fPCYoL8a0osvdTCe4pvOc9Rv5CpDsoOlf8BWBs2OWpeP0U2BktGvIsuUhmISmdYYGyrvTw==
 
-"@next/swc-android-arm-eabi@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2.tgz#806e3be9741bc14aafdfad0f0c4c6a8de5b77ee1"
-  integrity sha512-r2rrz+DZ8YYGqzVrbRrpP6GKzwozpOrnFbErc4k36vUTSFMag9yQahZfaBe06JYdqu/e5yhm/saIDEaSVPRP4g==
+"@next/swc-android-arm-eabi@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.2.tgz#66669b8aab5062f554b8e9905d855679aabf0342"
+  integrity sha512-X54UQCTFyOGnJP//Z71dPPlp4BCYcQL2ncikKXQcPzVpqPs4C3m+tKC8ivBNH6edAXkppwsLRz1/yQwgSZ9Swg==
 
 "@next/swc-android-arm64@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.2.0.tgz#cbd9e329cef386271d4e746c08416b5d69342c24"
   integrity sha512-1eEk91JHjczcJomxJ8X0XaUeNcp5Lx1U2Ic7j15ouJ83oRX+3GIslOuabW2oPkSgXbHkThMClhirKpvG98kwZg==
 
-"@next/swc-android-arm64@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.3.2.tgz#f9ec6b7fc746832a217ad6bb5478624d1a9a9822"
-  integrity sha512-B+TINJhCf+CrY1+b3/JWQlkecv53rAGa/gA7gi5B1cnBa/2Uvoe+Ue0JeCefTjfiyl1ScsyNx+NcESY8Ye2Ngg==
+"@next/swc-android-arm64@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-13.0.2.tgz#c0641d30525e0fb22bf1e2baf6c461d2d9e52f1a"
+  integrity sha512-1P00Kv8uKaLubqo7JzPrTqgFAzSOmfb8iwqJrOb9in5IvTRtNGlkR4hU0sXzqbQNM/+SaYxze6Z5ry1IDyb/cQ==
 
 "@next/swc-darwin-arm64@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.0.tgz#3473889157ba70b30ccdd4f59c46232d841744e2"
   integrity sha512-x5U5gJd7ZvrEtTFnBld9O2bUlX8opu7mIQUqRzj7KeWzBwPhrIzTTsQXAiNqsaMuaRPvyHBVW/5d/6g6+89Y8g==
 
-"@next/swc-darwin-arm64@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2.tgz#97c532d35c66ce6b6941ae24b5b8b267b9b0d0d8"
-  integrity sha512-PTUfe1ZrwjsiuTmr3bOM9lsoy5DCmfYsLOUF9ZVhtbi5MNJVmUTy4VZ06GfrvnCO5hGCr48z3vpFE9QZ0qLcPw==
+"@next/swc-darwin-arm64@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.2.tgz#d7e01a33393e83456dbfdc41446bb8a923968ff7"
+  integrity sha512-1zGIOkInkOLRv0QQGZ+3wffYsyKI4vIy62LYTvDWUn7TAYqnmXwougp9NSLqDeagLwgsv2URrykyAFixA/YqxA==
 
 "@next/swc-darwin-x64@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.0.tgz#b25198c3ef4c906000af49e4787a757965f760bb"
   integrity sha512-iwMNFsrAPjfedjKDv9AXPAV16PWIomP3qw/FfPaxkDVRbUls7BNdofBLzkQmqxqWh93WrawLwaqyXpJuAaiwJA==
 
-"@next/swc-darwin-x64@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2.tgz#e0cb4ff4b11faaff3a891bd1d18ed72f71e30ebe"
-  integrity sha512-1HkjmS9awwlaeEY8Y01nRSNkSv3y+qnC/mjMPe/W66hEh3QKa/LQHqHeS7NOdEs19B2mhZ7w+EgMRXdLQ0Su8w==
+"@next/swc-darwin-x64@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.2.tgz#d4a3fbe51edf871a675d89a7afdc78174d1e5841"
+  integrity sha512-ECDAjoMP1Y90cARaelS6X+k6BQx+MikAYJ8f/eaJrLur44NIOYc9HA/dgcTp5jenguY4yT8V+HCquLjAVle6fA==
 
 "@next/swc-freebsd-x64@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz#78e2213f8b703be0fef23a49507779b4a9842929"
   integrity sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==
 
-"@next/swc-freebsd-x64@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2.tgz#d7b93dd344cb67d1969565d0796c7b7d0217fccf"
-  integrity sha512-h5Mx0BKDCJ5Vu/U8e07esF6PjPv1EJgmRbYWTUZMAflu13MQpCJkKEJir7+BeRfTXRfgFf+llc7uocrpd7mcrg==
+"@next/swc-freebsd-x64@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.2.tgz#1b54c3f38d3b36f86663a8dfcc81ea05e01f5172"
+  integrity sha512-2DcL/ofQdBnQX3IoI9sjlIAyLCD1oZoUBuhrhWbejvBQjutWrI0JTEv9uG69WcxWhVMm3BCsjv8GK2/68OKp7A==
 
 "@next/swc-linux-arm-gnueabihf@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.0.tgz#80a4baf0ba699357e7420e2dea998908dcef5055"
   integrity sha512-/TJZkxaIpeEwnXh6A40trgwd40C5+LJroLUOEQwMOJdavLl62PjCA6dGl1pgooWLCIb5YdBQ0EG4ylzvLwS2+Q==
 
-"@next/swc-linux-arm-gnueabihf@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2.tgz#c2170a89effe00fdd65798c99684fd93a02b197c"
-  integrity sha512-EuRZAamoxfe/WoWRaC0zsCAoE4gs/mEhilcloNM4J5Mnb3PLY8PZV394W7t5tjBjItMCF7l2Ebwjwtm46tq2RA==
+"@next/swc-linux-arm-gnueabihf@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.2.tgz#18495cff32c0b2182cfbf677614219d7072214da"
+  integrity sha512-Y3OQF1CSBSWW2vGkmvOIuOUNqOq8qX7f1ZpcKUVWP3/Uq++DZmVi9d18lgnSe1I3QFqc+nXWyun9ljsN83j0sw==
 
 "@next/swc-linux-arm64-gnu@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.0.tgz#134a42ddea804d6bf04761607f774432c3126de6"
   integrity sha512-++WAB4ElXCSOKG9H8r4ENF8EaV+w0QkrpjehmryFkQXmt5juVXz+nKDVlCRMwJU7A1O0Mie82XyEoOrf6Np1pA==
 
-"@next/swc-linux-arm64-gnu@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2.tgz#26df7d7cdc18cf413f12a408179ee4ac315f383a"
-  integrity sha512-T9GCFyOIb4S3acA9LqflUYD+QZ94iZketHCqKdoO0Nx0OCHIgGJV5rotDe8TDXwh/goYpIfyHU4j1qqw4w4VnA==
+"@next/swc-linux-arm64-gnu@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.2.tgz#5fb2563651166c3c6f32bf9e2f9cc6a16a9ef783"
+  integrity sha512-mNyzwsFF6kwZYEjnGicx9ksDZYEZvyzEc1BtCu8vdZi/v8UeixQwCiAT6FyYX9uxMPEkzk8qiU0t0u9gvltsKw==
 
 "@next/swc-linux-arm64-musl@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.0.tgz#c781ac642ad35e0578d8a8d19c638b0f31c1a334"
   integrity sha512-XrqkHi/VglEn5zs2CYK6ofJGQySrd+Lr4YdmfJ7IhsCnMKkQY1ma9Hv5THwhZVof3e+6oFHrQ9bWrw9K4WTjFA==
 
-"@next/swc-linux-arm64-musl@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2.tgz#fd42232a6b10d9f9a4f71433d59c280a4532d06f"
-  integrity sha512-hxNVZS6L3c2z3l9EH2GP0MGQ9exu6O8cohYNZyqC9WUl6C03sEn8xzDH1y+NgD3fVurvYkGU5F0PDddJJLfDIw==
+"@next/swc-linux-arm64-musl@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.2.tgz#b9f33c5e17cfe04aa5769b717284cf80865761e6"
+  integrity sha512-M6SdYjWgRrY3tJBxz0663zCRPTu5BRONmxlftKWWHv9LjAJ59neTLaGj4rp0A08DkJglZIoCkLOzLrzST6TGag==
 
 "@next/swc-linux-x64-gnu@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.0.tgz#0e2235a59429eadd40ac8880aec18acdbc172a31"
   integrity sha512-MyhHbAKVjpn065WzRbqpLu2krj4kHLi6RITQdD1ee+uxq9r2yg5Qe02l24NxKW+1/lkmpusl4Y5Lks7rBiJn4w==
 
-"@next/swc-linux-x64-gnu@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2.tgz#5307579e3d8fbdb03adbe6cfc915b51548e0a103"
-  integrity sha512-fCPkLuwDwY8/QeXxciJJjDHG09liZym/Bhb4A+RLFQ877wUkwFsNWDUTSdUx0YXlYK/1gf67BKauqKkOKp6CYw==
+"@next/swc-linux-x64-gnu@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.2.tgz#29efcc2fd0122689d7e06c5b6b0883fe495db2bf"
+  integrity sha512-pi63RoxvG4ES1KS06Zpm0MATVIXTs/TIbLbdckeLoM40u1d3mQl/+hSSrLRSxzc2OtyL8fh92sM4gkJrQXAMAw==
 
 "@next/swc-linux-x64-musl@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.0.tgz#b0a10db0d9e16f079429588a58f71fa3c3d46178"
   integrity sha512-Tz1tJZ5egE0S/UqCd5V6ZPJsdSzv/8aa7FkwFmIJ9neLS8/00za+OY5pq470iZQbPrkTwpKzmfTTIPRVD5iqDg==
 
-"@next/swc-linux-x64-musl@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2.tgz#d5cb920a825a8dc80ffba8a6b797fb845af0b84c"
-  integrity sha512-o+GifBIQ2K+/MEFxHsxUZoU3bsuVFLXZYWd3idimFHiVdDCVYiKsY6mYMmKDlucX+9xRyOCkKL9Tjf+3tuXJpw==
+"@next/swc-linux-x64-musl@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.2.tgz#d68fdf6eefc57813fa91559c7089b49d6131ecab"
+  integrity sha512-9Pv91gfYnDONgjtRm78n64b/c54+azeHtlnqBLTnIFWSMBDRl1/WDkhKWIj3fBGPLimtK7Tko3ULR3og9RRUPw==
 
 "@next/swc-win32-arm64-msvc@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.0.tgz#3063f850c9db7b774c69e9be74ad59986cf6fc34"
   integrity sha512-0iRO/CPMCdCYUzuH6wXLnsfJX1ykBX4emOOvH0qIgtiZM0nVYbF8lkEyY2ph4XcsurpinS+ziWuYCXVqrOSqiw==
 
-"@next/swc-win32-arm64-msvc@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2.tgz#2a0d619e5bc0cec17ed093afd1ca6b1c37c2690c"
-  integrity sha512-crii66irzGGMSUR0L8r9+A06eTv7FTXqw4rgzJ33M79EwQJOdpY7RVKXLQMurUhniEeQEEOfamiEdPIi/qxisw==
+"@next/swc-win32-arm64-msvc@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.2.tgz#acdcb3023045f60cca510f659a2349895e6405bd"
+  integrity sha512-Nvewe6YZaizAkGHHprbMkYqQulBjZCHKBGKeFPwoPtOA+a2Qi4pZzc/qXFyC5/2A6Z0mr2U1zg9rd04WBYMwBw==
 
 "@next/swc-win32-ia32-msvc@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.0.tgz#001bbadf3d2cf006c4991f728d1d23e4d5c0e7cc"
   integrity sha512-8A26RJVcJHwIKm8xo/qk2ePRquJ6WCI2keV2qOW/Qm+ZXrPXHMIWPYABae/nKN243YFBNyPiHytjX37VrcpUhg==
 
-"@next/swc-win32-ia32-msvc@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2.tgz#769bef60d0d678c3d7606a4dc7fee018d6199227"
-  integrity sha512-5hRUSvn3MdQ4nVRu1rmKxq5YJzpTtZfaC/NyGw6wa4NSF1noUn/pdQGUr+I5Qz3CZkd1gZzzC0eaXQHlrk0E2g==
+"@next/swc-win32-ia32-msvc@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.2.tgz#a78ee9211471768febac9df915c2a8dbbcd05e41"
+  integrity sha512-ZUBYGZw5G3QrqDpRq1EWi3aHmvPZM8ijK5TFL6UbH16cYQ0JpANmuG2P66KB93Qe/lWWzbeAZk/tj1XqwoCuPA==
 
 "@next/swc-win32-x64-msvc@12.2.0":
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.0.tgz#9f66664f9122ca555b96a5f2fc6e2af677bf801b"
   integrity sha512-OI14ozFLThEV3ey6jE47zrzSTV/6eIMsvbwozo+XfdWqOPwQ7X00YkRx4GVMKMC0rM44oGS2gmwMKYpe4EblnA==
 
-"@next/swc-win32-x64-msvc@12.3.2":
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2.tgz#45beb4b9d28e6dd6abf63cab1c5b92dc84323a6b"
-  integrity sha512-tpQJYUH+TzPMIsdVl9fH8uDg47iwiNjKY+8e9da3dXqlkztKzjSw0OwSADoqh3KrifplXeKSta+BBGLdBqg3sg==
+"@next/swc-win32-x64-msvc@13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.2.tgz#e86c2de910cd68a17974db5556d4588737412c68"
+  integrity sha512-fA9uW1dm7C0mEYGcKlbmLcVm2sKcye+1kPxh2cM4jVR+kQQMtHWsjIzeSpe2grQLSDan06z4n6hbr8b1c3hA8w==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1731,10 +1731,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@testing-library/dom@^8.0.0":
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
-  integrity sha512-uxF4zmnLHHDlmW4l+0WDjcgLVwCvH+OVLpD8Dfp+Bjfz85prwxWGbwXgJdLtkgjD0qfOzkJF9SmA6YZPsMYX4w==
+"@testing-library/dom@^8.5.0":
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"
+  integrity sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
@@ -1760,14 +1760,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^12.1.5":
-  version "12.1.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
-  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+"@testing-library/react@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
+  integrity sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^8.0.0"
-    "@types/react-dom" "<18.0.0"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -1925,14 +1925,23 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react-dom@<18.0.0":
-  version "17.0.17"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
-  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
+"@types/react-dom@^18.0.0":
+  version "18.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.8.tgz#d2606d855186cd42cc1b11e63a71c39525441685"
+  integrity sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==
   dependencies:
-    "@types/react" "^17"
+    "@types/react" "*"
 
-"@types/react@^17", "@types/react@^17.0.4":
+"@types/react@*":
+  version "18.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.25.tgz#8b1dcd7e56fe7315535a4af25435e0bb55c8ae44"
+  integrity sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.4":
   version "17.0.48"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.48.tgz#a4532a8b91d7b27b8768b6fc0c3bccb760d15a6c"
   integrity sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==
@@ -2764,6 +2773,11 @@ cli-truncate@^2.1.0:
   dependencies:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
+
+client-only@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -5682,31 +5696,31 @@ next@^12.0.0:
     "@next/swc-win32-ia32-msvc" "12.2.0"
     "@next/swc-win32-x64-msvc" "12.2.0"
 
-next@^12.3.2:
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.3.2.tgz#3a3356a8d752726128825a8bdf17f2a3b3f861cf"
-  integrity sha512-orzvvebCwOqaz1eA5ZA0R5dbKxqtJyw7yeig7kDspu6p8OrplfyelzpvMHcDTKscv/l0nn/0l0v3mSsE8w4k7A==
+next@^13.0.0:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.0.2.tgz#b8c8642c70f736ed91105645391d335fc51c8f62"
+  integrity sha512-uQ5z5e4D9mOe8+upy6bQdYYjo/kk1v3jMW87kTy2TgAyAsEO+CkwRnMgyZ4JoHEnhPZLHwh7dk0XymRNLe1gFw==
   dependencies:
-    "@next/env" "12.3.2"
+    "@next/env" "13.0.2"
     "@swc/helpers" "0.4.11"
     caniuse-lite "^1.0.30001406"
     postcss "8.4.14"
-    styled-jsx "5.0.7"
+    styled-jsx "5.1.0"
     use-sync-external-store "1.2.0"
   optionalDependencies:
-    "@next/swc-android-arm-eabi" "12.3.2"
-    "@next/swc-android-arm64" "12.3.2"
-    "@next/swc-darwin-arm64" "12.3.2"
-    "@next/swc-darwin-x64" "12.3.2"
-    "@next/swc-freebsd-x64" "12.3.2"
-    "@next/swc-linux-arm-gnueabihf" "12.3.2"
-    "@next/swc-linux-arm64-gnu" "12.3.2"
-    "@next/swc-linux-arm64-musl" "12.3.2"
-    "@next/swc-linux-x64-gnu" "12.3.2"
-    "@next/swc-linux-x64-musl" "12.3.2"
-    "@next/swc-win32-arm64-msvc" "12.3.2"
-    "@next/swc-win32-ia32-msvc" "12.3.2"
-    "@next/swc-win32-x64-msvc" "12.3.2"
+    "@next/swc-android-arm-eabi" "13.0.2"
+    "@next/swc-android-arm64" "13.0.2"
+    "@next/swc-darwin-arm64" "13.0.2"
+    "@next/swc-darwin-x64" "13.0.2"
+    "@next/swc-freebsd-x64" "13.0.2"
+    "@next/swc-linux-arm-gnueabihf" "13.0.2"
+    "@next/swc-linux-arm64-gnu" "13.0.2"
+    "@next/swc-linux-arm64-musl" "13.0.2"
+    "@next/swc-linux-x64-gnu" "13.0.2"
+    "@next/swc-linux-x64-musl" "13.0.2"
+    "@next/swc-win32-arm64-msvc" "13.0.2"
+    "@next/swc-win32-ia32-msvc" "13.0.2"
+    "@next/swc-win32-x64-msvc" "13.0.2"
 
 node-abi@^3.3.0:
   version "3.22.0"
@@ -6547,7 +6561,7 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^17.0.0, react-dom@^17.0.2:
+react-dom@^17.0.0:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -6555,6 +6569,14 @@ react-dom@^17.0.0, react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.23.0"
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -6576,13 +6598,20 @@ react-property@2.0.0:
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
   integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
 
-react@^17.0.0, react@^17.0.2:
+react@^17.0.0:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -6886,6 +6915,13 @@ scheduler@^0.20.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+  dependencies:
+    loose-envify "^1.1.0"
 
 semver@7.0.0:
   version "7.0.0"
@@ -7199,10 +7235,12 @@ styled-jsx@5.0.2:
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.2.tgz#ff230fd593b737e9e68b630a694d460425478729"
   integrity sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==
 
-styled-jsx@5.0.7:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.7.tgz#be44afc53771b983769ac654d355ca8d019dff48"
-  integrity sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==
+styled-jsx@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.0.tgz#4a5622ab9714bd3fcfaeec292aa555871f057563"
+  integrity sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==
+  dependencies:
+    client-only "0.0.1"
 
 stylehacks@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
This PR updates basic-starter to Next.js 13. This also updates the version constraint in `next-acms` to allow Next.js 13.

To update to Next.js 13, this PR:

- Updates usages of `<Link>` to use the Next.js 13 API: https://nextjs.org/blog/next-13#nextlink
- Updates usages of `<Image>` to use the Next.js 13 API: https://nextjs.org/blog/next-13#nextimage
- Updates `<title>` element into a text node. (For context: https://github.com/vercel/next.js/discussions/38256)
- Updates React and related libraries

⚠️ This does PR does not yet use the the new `/app` directory since it is still experimental.